### PR TITLE
Implement gateway manager with credential prompt

### DIFF
--- a/IBKRConnect/ContentView.swift
+++ b/IBKRConnect/ContentView.swift
@@ -1,24 +1,39 @@
-//
-//  ContentView.swift
-//  IBKRConnect
-//
-//  Created by sdrasco on 28/05/2025.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var manager = GatewayManager()
+    @State private var showingCredentials = false
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        VStack(spacing: 16) {
+            Circle()
+                .fill(manager.isConnected ? Color.green : Color.red)
+                .frame(width: 12, height: 12)
+            Button(manager.isConnected ? "Disconnect" : "Connect") {
+                if manager.isConnected {
+                    manager.disconnect()
+                } else {
+                    if manager.hasCredentials {
+                        manager.connect()
+                    } else {
+                        showingCredentials = true
+                    }
+                }
+            }
+            .frame(width: 120)
         }
         .padding()
+        .frame(minWidth: 200, minHeight: 120)
+        .sheet(isPresented: $showingCredentials) {
+            CredentialsSheet { creds in
+                manager.saveCredentials(creds)
+                manager.connect()
+            }
+        }
     }
 }
 
 #Preview {
     ContentView()
 }
+

--- a/IBKRConnect/CredentialsSheet.swift
+++ b/IBKRConnect/CredentialsSheet.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct CredentialsSheet: View {
+    @State private var username: String = ""
+    @State private var password: String = ""
+    var onSave: (Credentials) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Enter Gateway Credentials")
+                .font(.headline)
+            TextField("Username", text: $username)
+                .textFieldStyle(.roundedBorder)
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+            HStack {
+                Button("Cancel") {
+                    dismiss()
+                }
+                Spacer()
+                Button("Save") {
+                    onSave(Credentials(username: username, password: password))
+                    dismiss()
+                }
+            }
+        }
+        .padding()
+        .frame(width: 300)
+    }
+}
+
+#Preview {
+    CredentialsSheet(onSave: { _ in })
+}

--- a/IBKRConnect/GatewayManager.swift
+++ b/IBKRConnect/GatewayManager.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Security
+
+struct Credentials {
+    var username: String
+    var password: String
+}
+
+class GatewayManager: ObservableObject {
+    @Published var isConnected = false
+    private var process: Process?
+    private var gatewayURL: URL?
+    private let serviceName = "IBKRConnect"
+
+    init() {
+        if let path = UserDefaults.standard.string(forKey: "gatewayPath") {
+            gatewayURL = URL(fileURLWithPath: path)
+        }
+    }
+
+    var hasCredentials: Bool {
+        storedCredentials() != nil
+    }
+
+    func promptForGateway() {
+        let panel = NSOpenPanel()
+        panel.title = "Select Client Portal Gateway"
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            gatewayURL = url
+            UserDefaults.standard.set(url.path, forKey: "gatewayPath")
+        } else {
+            if let helpURL = URL(string: "https://www.interactivebrokers.com/campus/ibkr-api-page/cpapi-v1/#gw-step-one") {
+                NSWorkspace.shared.open(helpURL)
+            }
+        }
+    }
+
+    func storedCredentials() -> Credentials? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecReturnAttributes as String: true,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecSuccess,
+           let existingItem = item as? [String: Any],
+           let passwordData = existingItem[kSecValueData as String] as? Data,
+           let password = String(data: passwordData, encoding: .utf8),
+           let username = existingItem[kSecAttrAccount as String] as? String {
+            return Credentials(username: username, password: password)
+        }
+        return nil
+    }
+
+    func saveCredentials(_ creds: Credentials) {
+        let passwordData = creds.password.data(using: .utf8)!
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: creds.username,
+            kSecValueData as String: passwordData
+        ]
+        SecItemDelete(query as CFDictionary)
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    func connect() {
+        guard process == nil else { return }
+        guard let url = gatewayURL else {
+            promptForGateway()
+            return
+        }
+        let process = Process()
+        process.executableURL = url
+        if let creds = storedCredentials() {
+            process.arguments = ["-username", creds.username, "-password", creds.password]
+        }
+        do {
+            try process.run()
+            self.process = process
+            self.isConnected = true
+        } catch {
+            print("Failed to launch gateway: \(error)")
+        }
+    }
+
+    func disconnect() {
+        process?.terminate()
+        process = nil
+        isConnected = false
+    }
+}
+

--- a/IBKRConnect/IBKRConnect.entitlements
+++ b/IBKRConnect/IBKRConnect.entitlements
@@ -2,9 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
+        <key>com.apple.security.app-sandbox</key>
+        <true/>
+        <key>com.apple.security.files.user-selected.read-write</key>
+        <true/>
+        <key>com.apple.security.network.client</key>
+        <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- build a GatewayManager to launch the Client Portal Gateway
- persist gateway path and credentials
- create a credential input sheet and present it from `ContentView`
- add network and user-selected file entitlements for sandboxing

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `xcodebuild test -scheme IBKRConnect -destination 'platform=macOS'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841654e0d74832583a0d1c2b786fedd