### PR TITLE
Fix sandbox bookmark handling

### DIFF
--- a/IBKRConnect/GatewayManager.swift
+++ b/IBKRConnect/GatewayManager.swift
@@ -12,11 +12,21 @@ class GatewayManager: ObservableObject {
     @Published private(set) var hasCredentials = false
     private var process: Process?
     private var gatewayURL: URL?
+    private var gatewayBookmark: Data?
     private let serviceName = "IBKRConnect"
     
     init() {
-        if let path = UserDefaults.standard.string(forKey: "gatewayPath") {
-            gatewayURL = URL(fileURLWithPath: path)
+        if let data = UserDefaults.standard.data(forKey: "gatewayBookmark") {
+            var isStale = false
+            if let url = try? URL(resolvingBookmarkData: data,
+                                  options: [.withSecurityScope],
+                                  bookmarkDataIsStale: &isStale) {
+                gatewayURL = url
+                gatewayBookmark = data
+                if isStale {
+                    saveBookmark(for: url)
+                }
+            }
         }
         hasCredentials = storedCredentials() != nil
     }
@@ -29,11 +39,25 @@ class GatewayManager: ObservableObject {
         panel.allowsMultipleSelection = false
         if panel.runModal() == .OK, let url = panel.url {
             gatewayURL = url
-            UserDefaults.standard.set(url.path, forKey: "gatewayPath")
+            let access = url.startAccessingSecurityScopedResource()
+            saveBookmark(for: url)
+            if access { url.stopAccessingSecurityScopedResource() }
         } else {
             if let helpURL = URL(string: "https://www.interactivebrokers.com/campus/ibkr-api-page/cpapi-v1/#gw-step-one") {
                 NSWorkspace.shared.open(helpURL)
             }
+        }
+    }
+
+    private func saveBookmark(for url: URL) {
+        do {
+            let data = try url.bookmarkData(options: .withSecurityScope,
+                                           includingResourceValuesForKeys: nil,
+                                           relativeTo: nil)
+            gatewayBookmark = data
+            UserDefaults.standard.set(data, forKey: "gatewayBookmark")
+        } catch {
+            print("Failed to save bookmark: \(error)")
         }
     }
 
@@ -76,6 +100,7 @@ class GatewayManager: ObservableObject {
             promptForGateway()
             return
         }
+        let access = url.startAccessingSecurityScopedResource()
         let process = Process()
         process.executableURL = url
         if let creds = storedCredentials() {
@@ -87,6 +112,13 @@ class GatewayManager: ObservableObject {
             self.isConnected = true
         } catch {
             print("Failed to launch gateway: \(error)")
+            if access { url.stopAccessingSecurityScopedResource() }
+            return
+        }
+        if access {
+            process.terminationHandler = { _ in
+                url.stopAccessingSecurityScopedResource()
+            }
         }
     }
 
@@ -94,5 +126,8 @@ class GatewayManager: ObservableObject {
         process?.terminate()
         process = nil
         isConnected = false
+        if let url = gatewayURL {
+            url.stopAccessingSecurityScopedResource()
+        }
     }
 }

--- a/IBKRConnect/IBKRConnect.entitlements
+++ b/IBKRConnect/IBKRConnect.entitlements
@@ -6,6 +6,8 @@
         <true/>
         <key>com.apple.security.files.user-selected.read-write</key>
         <true/>
+        <key>com.apple.security.files.bookmarks.app-scope</key>
+        <true/>
         <key>com.apple.security.network.client</key>
         <true/>
 </dict>


### PR DESCRIPTION
## Summary
- start and stop security-scoped access when picking the gateway
- drop unsupported migration from stored path to bookmark

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68417e98996883258fa0321cc27cfe5a